### PR TITLE
Added release automation and out-of-the-box binaries for linux/amd64 linux/arm64 linux/arm windows/amd64 darwin/amd64 darwin/arm64

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish binaries to GH
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+      - name: Make Release
+        run: make release
+      - name: Upload release binaries
+        uses: alexellis/upload-assets@0.3.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          asset_paths: '["./dist/redisgraph-benchmark-go_*"]'

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ coverage.txt
 # Dependency directories (remove the comment below to include it)
  vendor/
 
+# Dist binaries
+dist/
+
 # Go sum
 go.sum
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,36 @@
 # redisgraph-benchmark-go
 
+[![license](https://img.shields.io/github/license/RedisGraph/redisgraph-benchmark-go.svg)](https://github.com/RedisGraph/redisgraph-benchmark-go)
+[![GitHub issues](https://img.shields.io/github/release/RedisGraph/redisgraph-benchmark-go.svg)](https://github.com/RedisGraph/redisgraph-benchmark-go/releases/latest)
+[![Discord](https://img.shields.io/discord/697882427875393627?style=flat-square)](https://discord.gg/gWBRT6P)
+
 ## Overview
 
 This repo contains code to quick benchmark RedisGraph, using the official [redisgraph-go](https://github.com/RedisGraph/redisgraph-go) client.  
+The tool is written in Go and is cross-compiled for Linux, Windows, MacOS and even on Raspberry Pi.
 
 ## Installation
+
+
+### Standalone binaries ( no Golang needed )
+
+If you don't have Go on your machine and just want to use the produced binaries you can download 
+the prebuilt bins for Windows, Linux, and Darwin from the [Releases page](https://github.com/RedisGraph/redisgraph-benchmark-go/releases).
+
+Here's an example on how to use the above links:
+```bash
+# Fetch this repo
+wget https://github.com/RedisGraph/redisgraph-benchmark-go/releases/download/v0.0.1/redisgraph-benchmark-go_linux_amd64
+
+# change permissions
+chmod 755 redisgraph-benchmark-go_linux_amd64
+
+# give it a try 
+./redisgraph-benchmark-go_linux_amd64 --help
+```
+
+
+## Installation in a Golang env
 
 The easiest way to get and install the redisgraph-benchmark-go Go program is to use
 `go get` and then `go install`:

--- a/bin_info.go
+++ b/bin_info.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Vars only for git sha and diff handling
+var GitSHA1 string = ""
+var GitDirty string = "0"
+
+// internal function to return value of GitSHA1 var, which is filled in link time
+func toolGitSHA1() string {
+	return GitSHA1
+}
+
+// this internal function will check for the number of altered lines that are not yet committed
+// and return true in that case
+func toolGitDirty() (dirty bool) {
+	dirty = false
+	dirtyLines, err := strconv.Atoi(strings.TrimSpace(GitDirty))
+	if err == nil {
+		dirty = (dirtyLines != 0)
+	}
+	return
+}

--- a/redisgraph-bechmark-go.go
+++ b/redisgraph-bechmark-go.go
@@ -33,7 +33,17 @@ func main() {
 	// in the meantime added this two fake vars
 	var loopV = false
 	var loop *bool = &loopV
+	version := flag.Bool("v", false, "Output version and exit")
 	flag.Parse()
+	git_sha := toolGitSHA1()
+	git_dirty_str := ""
+	if toolGitDirty() {
+		git_dirty_str = "-dirty"
+	}
+	log.Printf("redisgraph-benchmark-go (git_sha1:%s%s)\n", git_sha, git_dirty_str)
+	if *version {
+		os.Exit(0)
+	}
 	if len(benchmarkQueries) < 1 {
 		log.Fatalf("You need to specify at least a query with the -query parameter. For example: -query=\"CREATE (n)\"")
 	}


### PR DESCRIPTION
This PR fixes #10 and makes it easy to release and publish ( given you have the right permission ) the benchmark binaries for 6 different OS/Archs (`"linux/amd64 linux/arm64 linux/arm windows/amd64 darwin/amd64 darwin/arm64"`). This makes it possible to run the benchmark without Go on the machine.

Apart from it it fixes #11 by outputing the git_sha and if the code was altered as part of the log.
Sample output:
```
$ ./dist/redisgraph-benchmark-go_linux_amd64 -v
2021/05/19 16:11:43 redisgraph-benchmark-go (git_sha1:7c575e71e82a7067d8cfdeeaf6f2bd3811a4401d)
```

After we've reviewed this PR we should release v0.0.1 so that the link on the Readme will work as expected.
