### PR TITLE
Added ratio/absoute difference between external and internal latency summaries

### DIFF
--- a/redisgraph-bechmark-go.go
+++ b/redisgraph-bechmark-go.go
@@ -178,8 +178,13 @@ func main() {
 	testResult.FillDurationInfo(startTime, endTime, duration)
 	testResult.BenchmarkFullyRun = totalCommands == *numberRequests
 	testResult.IssuedCommands = totalCommands
-	testResult.OverallGraphInternalLatencies = GetOverallLatencies(queries, serverSide_PerQuery_GraphInternalTime_OverallLatencies, serverSide_AllQueries_GraphInternalTime_OverallLatencies)
-	testResult.OverallClientLatencies = GetOverallLatencies(queries, clientSide_PerQuery_OverallLatencies, clientSide_AllQueries_OverallLatencies)
+	overallGraphInternalLatencies, internalLatencyMap := GetOverallLatencies(queries, serverSide_PerQuery_GraphInternalTime_OverallLatencies, serverSide_AllQueries_GraphInternalTime_OverallLatencies)
+	overallClientLatencies, clientLatencyMap := GetOverallLatencies(queries, clientSide_PerQuery_OverallLatencies, clientSide_AllQueries_OverallLatencies)
+	relativeLatencyDiff, absoluteLatencyDiff := GenerateInternalExternalRatioLatencies(internalLatencyMap, clientLatencyMap)
+	testResult.OverallClientLatencies = overallClientLatencies
+	testResult.OverallGraphInternalLatencies = overallGraphInternalLatencies
+	testResult.AbsoluteInternalExternalLatencyDiff = absoluteLatencyDiff
+	testResult.RelativeInternalExternalLatencyDiff = relativeLatencyDiff
 	testResult.OverallQueryRates = GetOverallRatesMap(duration, queries, clientSide_PerQuery_OverallLatencies, clientSide_AllQueries_OverallLatencies)
 	testResult.DBSpecificConfigs = GetDBConfigsMap(redisgraphVersion)
 	testResult.Totals = GetTotalsMap(queries, clientSide_PerQuery_OverallLatencies, clientSide_AllQueries_OverallLatencies, errorsPerQuery, totalNodesCreatedPerQuery, totalNodesDeletedPerQuery, totalLabelsAddedPerQuery, totalPropertiesSetPerQuery, totalRelationshipsCreatedPerQuery, totalRelationshipsDeletedPerQuery)


### PR DESCRIPTION
This PR add 2 new metric groups related to the differences between external and internal latency summaries. Fixes #19 

sample output after running:
```
./redisgraph-benchmark-go -n 100 -graph-key graph -query "CREATE (u:User)" -json-out-file 1.json -c 1
```

```
(...)
 "OverallRelativeInternalExternalLatencyDiff": {
  "avg": 4.199525566684239,
  "q100": 3.369369369369369,
  "q50": 4.338028169014085,
  "q95": 4.121951219512195,
  "q99": 3.644171779141104,
  "q999": 3.369369369369369
 },
 "OverallAbsoluteInternalExternalLatencyDiff": {
  "avg": 0.24278,
  "q0": 0,
  "q100": 0.526,
  "q50": 0.237,
  "q95": 0.384,
  "q99": 0.43099999999999994,
  "q999": 0.526
 },

```